### PR TITLE
괄호 앞 띄어쓰기 검사시 ASCII가 아니면 검사를 안하는 문제

### DIFF
--- a/KPC/checks/language/punctuation.py
+++ b/KPC/checks/language/punctuation.py
@@ -5,7 +5,7 @@ from KPC.classes import Error, BaseCheck
 
 # 괄호 띄어쓰기
 check_list = [
-    [ re.compile('[\uac00-\ud7a3] \(\w', re.UNICODE), '맞춤법 규정에 따라 괄호 앞에 띄어 쓰지 않습니다' ]
+    [ re.compile('[\uac00-\ud7a3] \(\S', re.UNICODE), '맞춤법 규정에 따라 괄호 앞에 띄어 쓰지 않습니다' ]
 ]
 
 class PunctuationCheck(BaseCheck):


### PR DESCRIPTION
"섭씨 온도 (°C)"와 같은 경우 "°"가 \w에 들어가지 않아 검사가 되지 않는 것 같아 부족한 실력이지만 고쳐보았습니다.
